### PR TITLE
Replace characters in subnet that result in invalid python names

### DIFF
--- a/tasks/subnets.yml
+++ b/tasks/subnets.yml
@@ -9,7 +9,7 @@
 
 - name: set subnet facts
   set_fact:
-   "{{item.tags.Name | regex_replace('-', '_') | regex_replace('\.', '_') }}": "{{item.id}}"
+   "{{item.tags.Name | replace('-', '_') | replace('\.', '_') }}": "{{item.id}}"
   with_items: "{{subnet_facts.subnets}}"
 
 # - debug: msg={{administration_primary}}


### PR DESCRIPTION
When calling set_fact, replace characters that would result in invalid python identifiers with `_`
